### PR TITLE
Hide overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,7 +26,8 @@ body {
   font-size: 18px;
   font-weight: 400;
   margin: 0;
-  text-align: left; }
+  text-align: left;
+  overflow-x: hidden; }
 
 a {
   border-bottom: 1px solid #1E3A29;


### PR DESCRIPTION
The background animation does not scale properly and therefore overflow on the x-axis can be seen on smaller devices. This change would just remove that overflow by cutting it away, with the animation still working as before.